### PR TITLE
timestamp correction

### DIFF
--- a/cryptofeed/exchanges/kucoin.py
+++ b/cryptofeed/exchanges/kucoin.py
@@ -343,7 +343,11 @@ class KuCoin(Feed):
 
         self.seq_no[symbol] = data['sequenceEnd']
 
-        ts = data['time'] / 1000
+        if 'time' in data:
+            ts = data['time'] / 1000
+        else:
+            LOG.debug("No timestamp data returned by Kucoin websocket.")
+            ts = None
         delta = {BID: [], ASK: []}
         for s, side in (('bids', BID), ('asks', ASK)):
             for update in data['changes'][s]:


### PR DESCRIPTION
Kucoin feed doesn't seem to include the `time` field listed in their documentation. Workaround included for when it is not available.

- [x] - Tested
- [ ] - Changelog updated
- [ ] - Tests run and pass
- [ ] - Flake8 run and all errors/warnings resolved
- [ ] - Contributors file updated (optional)
