### PR TITLE
Kucoin debugging.

### DIFF
--- a/cryptofeed/exchanges/kucoin.py
+++ b/cryptofeed/exchanges/kucoin.py
@@ -251,20 +251,24 @@ class KuCoin(Feed):
         }
         """
         data = msg["data"]
-        oi = OrderInfo(
-            self.id,
-            self.exchange_symbol_to_std_symbol(data['symbol']),
-            data['orderId'],
-            SELL if data['side'].lower() == 'sell' else BUY,
-            self.normalize_order_status(data),
-            LIMIT if data['orderType'].lower() == 'limit' else MARKET if data['orderType'].lower() == 'market' else None,
-            Decimal(data['price']),
-            Decimal(data['size']),
-            Decimal(data['remainSize']),
-            data["ts"] / 1000,
-            raw=data
-        )
-        await self.callback(ORDER_INFO, oi, timestamp)
+        if "price" in data:
+            oi = OrderInfo(
+                self.id,
+                self.exchange_symbol_to_std_symbol(data['symbol']),
+                data['orderId'],
+                SELL if data['side'].lower() == 'sell' else BUY,
+                self.normalize_order_status(data),
+                LIMIT if data['orderType'].lower() == 'limit' else MARKET if data['orderType'].lower() == 'market' else None,
+                Decimal(data['price']),
+                Decimal(data['size']),
+                Decimal(data['remainSize']),
+                data["ts"] / 1000,
+                raw=data
+            )
+            await self.callback(ORDER_INFO, oi, timestamp)
+        else:
+            LOG.warning("Key error: 'price' not in _order_update message data.")
+            LOG.warning(data)
 
     @staticmethod
     def normalize_order_status(order: dict):


### PR DESCRIPTION
Traps the situation where `price` is missing from `msg['data']`.

```
2022-12-21 15:36:40,201 : ERROR : KUCOIN.ws.1: encountered an exception, reconnecting in 1.0 seconds
 Traceback (most recent call last):
   File "/root/.cache/pypoetry/virtualenvs/exchange-feed-9TtSrW0h-py3.10/lib/python3.10/site-packages/cryptofeed/connection_handler.py", line 69, in _create_connection
     await self._handler(connection, self.handler)
   File "/root/.cache/pypoetry/virtualenvs/exchange-feed-9TtSrW0h-py3.10/lib/python3.10/site-packages/cryptofeed/connection_handler.py", line 119, in _handler
     await handler(message, connection, self.conn.last_message)
   File "/root/.cache/pypoetry/virtualenvs/exchange-feed-9TtSrW0h-py3.10/lib/python3.10/site-packages/cryptofeed/exchanges/kucoin.py", line 393, in message_handler
     await self._order_update(msg, timestamp)
   File "/root/.cache/pypoetry/virtualenvs/exchange-feed-9TtSrW0h-py3.10/lib/python3.10/site-packages/cryptofeed/exchanges/kucoin.py", line 261, in _order_update
     Decimal(data['price']),
 KeyError: 'price'
```