### PR TITLE
Add support for getting trade history from Binance, Gate, and Kucoin

### DIFF
--- a/cryptofeed/exchanges/gateio.py
+++ b/cryptofeed/exchanges/gateio.py
@@ -18,6 +18,7 @@ from cryptofeed.connection import AsyncConnection, RestEndpoint, Routes, Websock
 from cryptofeed.defines import BID, ASK, CANCELLED, CANDLES, FILLED, GATEIO, L2_BOOK, OPEN, ORDER_INFO, TICKER, TRADES, BUY, SELL, BALANCES, MARKET, LIMIT
 from cryptofeed.feed import Feed
 from cryptofeed.symbols import Symbol
+from cryptofeed.exchanges.mixins.gateio_rest import GateioRestMixin
 from cryptofeed.types import OrderBook, Trade, Ticker, Candle, Balance, OrderInfo
 from cryptofeed.util.time import timedelta_str_to_sec
 
@@ -25,7 +26,7 @@ from cryptofeed.util.time import timedelta_str_to_sec
 LOG = logging.getLogger('feedhandler')
 
 
-class Gateio(Feed):
+class Gateio(Feed, GateioRestMixin):
     id = GATEIO
     websocket_endpoints = [WebsocketEndpoint('wss://api.gateio.ws/ws/v4/', options={'compression': None})]
     rest_endpoints = [

--- a/cryptofeed/exchanges/kucoin.py
+++ b/cryptofeed/exchanges/kucoin.py
@@ -18,6 +18,7 @@ from cryptofeed.defines import ASK, BID, BUY, CANDLES, KUCOIN, L2_BOOK, LIMIT, M
 from cryptofeed.feed import Feed
 from cryptofeed.util.time import timedelta_str_to_sec
 from cryptofeed.symbols import Symbol
+from cryptofeed.exchanges.mixins.kucoin_rest import KucoinRestMixin
 from cryptofeed.connection import AsyncConnection, RestEndpoint, Routes, WebsocketEndpoint
 from cryptofeed.types import OrderBook, Trade, Ticker, Candle, OrderInfo, Balance
 
@@ -25,7 +26,7 @@ from cryptofeed.types import OrderBook, Trade, Ticker, Candle, OrderInfo, Balanc
 LOG = logging.getLogger('feedhandler')
 
 
-class KuCoin(Feed):
+class KuCoin(Feed, KucoinRestMixin):
     id = KUCOIN
     websocket_endpoints = None
     rest_endpoints = [

--- a/cryptofeed/exchanges/mixins/gateio_rest.py
+++ b/cryptofeed/exchanges/mixins/gateio_rest.py
@@ -1,0 +1,71 @@
+from decimal import Decimal
+import hashlib
+import hmac
+import logging
+import time
+from urllib.parse import urlencode
+
+from yapic import json
+
+from cryptofeed.exchange import RestExchange
+from cryptofeed.defines import BUY, SELL, TRADE_HISTORY, GET, POST, DELETE
+
+LOG = logging.getLogger('feedhandler')
+
+
+class GateioRestMixin(RestExchange):
+    api = "https://api.gateio.ws"
+    rest_channels = (
+        TRADE_HISTORY
+    )
+
+    def gen_sign_http(self, method, url, query_string=None, payload_string=None):
+        t = time.time()
+        m = hashlib.sha512()
+        m.update((payload_string or "").encode('utf-8'))
+        hashed_payload = m.hexdigest()
+        s = '%s\n%s\n%s\n%s\n%s' % (method, url, query_string or "", hashed_payload, t)
+        sign = hmac.new(self.key_secret.encode('utf-8'), s.encode('utf-8'), hashlib.sha512).hexdigest()
+        return {'method': 'api_key', 'KEY': self.key_id, 'Timestamp': str(t), 'SIGN': sign}
+
+    async def _request(self, method: str, endpoint: str, auth: bool = False, payload={}, api=None):
+        header = {'Accept': 'application/json', 'Content-Type': 'application/json'}
+        query_string = urlencode(payload)
+
+        if not api:
+            api = self.api
+
+        url = f'{api}{endpoint}?{query_string}'
+        if auth:
+            sign_headers = self.gen_sign_http(method, endpoint, query_string)
+            header.update(sign_headers)
+        if method == GET:
+            data = await self.http_conn.read(url, header=header)
+        elif method == POST:
+            data = await self.http_conn.write(url, msg=None, header=header)
+        elif method == DELETE:
+            data = await self.http_conn.delete(url, header=header)
+        return json.loads(data, parse_float=Decimal)
+    
+    async def trade_history(self, symbol: str, start=None, end=None):
+        sym = self.std_symbol_to_exchange_symbol(symbol)
+        params = { 'currency_pair': sym }
+
+        if start:
+            params['from'] = self._datetime_normalize(start) * 1000
+
+        data = await self._request(GET, '/api/v4/spot/my_trades', auth=True, payload=params)
+        return [
+            {
+                'symbol': symbol,
+                'price': Decimal(trade['price']),
+                'amount': Decimal(trade['amount']),
+                'timestamp': trade['create_time'] / 1000,
+                'side': BUY if trade['side'].lower() == 'buy' else SELL,
+                'fee_currency': trade['fee_currency'],
+                'fee_amount': trade['fee'],
+                'trade_id': trade['id'],
+                'order_id': trade['order_id']
+            }
+            for trade in data
+        ]

--- a/cryptofeed/exchanges/mixins/kucoin_rest.py
+++ b/cryptofeed/exchanges/mixins/kucoin_rest.py
@@ -1,0 +1,85 @@
+import base64
+from decimal import Decimal
+import hmac
+import logging
+import time
+from urllib.parse import urlencode
+
+from yapic import json
+
+from cryptofeed.exchange import RestExchange
+from cryptofeed.defines import BUY, SELL, TRADE_HISTORY, GET, POST, DELETE
+
+LOG = logging.getLogger('feedhandler')
+
+
+class KucoinRestMixin(RestExchange):
+    api = "https://api.kucoin.com"
+    sandbox_api = "https://openapi-sandbox.kucoin.com"
+    rest_channels = (
+        TRADE_HISTORY
+    )
+
+    def generate_token(self, str_to_sign: str) -> dict:
+        # https://docs.kucoin.com/#authentication
+
+        # Now required to pass timestamp with string to sign. Timestamp should exactly match header timestamp
+        now = str(int(time.time() * 1000))
+        str_to_sign = now + str_to_sign
+        signature = base64.b64encode(hmac.new(self.key_secret.encode('utf-8'), str_to_sign.encode('utf-8'), hashlib.sha256).digest())
+        # Passphrase must now be encrypted by key_secret
+        passphrase = base64.b64encode(hmac.new(self.key_secret.encode('utf-8'), self.key_passphrase.encode('utf-8'), hashlib.sha256).digest())
+
+        # API key version is currently 2 (whereas API version is anywhere from 1-3 ¯\_(ツ)_/¯)
+        header = {
+            "KC-API-KEY": self.key_id,
+            "KC-API-SIGN": signature.decode(),
+            "KC-API-TIMESTAMP": now,
+            "KC-API-PASSPHRASE": passphrase.decode(),
+            "KC-API-KEY-VERSION": "2"
+        }
+        return header
+    
+    async def _request(self, method: str, endpoint: str, auth: bool = False, payload={}, api=None):
+        query_string = urlencode(payload)
+
+        if not api:
+            api = self.api
+
+        if self.sandbox:
+            api = self.sandbox_api
+
+        url = f'{api}{endpoint}?{query_string}'
+        if auth:
+            str_to_sign = method + endpoint + "?" + query_string
+            header = self.generate_token(str_to_sign)
+        if method == GET:
+            data = await self.http_conn.read(url, header=header)
+        elif method == POST:
+            data = await self.http_conn.write(url, msg=None, header=header)
+        elif method == DELETE:
+            data = await self.http_conn.delete(url, header=header)
+        return json.loads(data, parse_float=Decimal)
+    
+    async def trade_history(self, symbol: str, start=None, end=None):
+        sym = self.std_symbol_to_exchange_symbol(symbol)
+        params = { 'symbol': sym }
+
+        if start:
+            params['startAt'] = self._datetime_normalize(start) * 1000
+
+        data = await self._request(GET, '/api/v1/fills', auth=True, payload=params)
+        return [
+            {
+                'symbol': symbol,
+                'price': Decimal(trade['price']),
+                'amount': Decimal(trade['size']),
+                'timestamp': trade['createdAt'] / 1000,
+                'side': BUY if trade['side'].lower() == 'buy' else SELL,
+                'fee_currency': trade['feeCurrency'],
+                'fee_amount': trade['fee'],
+                'trade_id': trade['tradeId'],
+                'order_id': trade['orderId']
+            }
+            for trade in data["data"]["items"]
+        ]


### PR DESCRIPTION
This Pull Request (PR) introduces a new feature to the cryptofeed project. The feature focuses on adding support for retrieving trade history from three major cryptocurrency exchanges - Binance, Gate, and Kucoin.

The changes include:

Modification of the Gateio and KuCoin classes in their respective files (gateio.py and kucoin.py), now inheriting from newly created Mixins to support the retrieval of trade history from their REST APIs.

The creation of three new mixin classes - BinanceRestMixin, GateioRestMixin, and KucoinRestMixin in their respective files. These Mixins provide the REST implementation for the trade_history method for each of the three exchanges.

The BinanceRestMixin class also received an update to include TRADE_HISTORY in the rest_channels attribute.